### PR TITLE
:bug: fixing bugs preventing saving tokens in the databse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,10 @@ SALLA_AUTHORIZATION_MODE=easy
 SALLA_APP_ID=
 
 # Database 
-DATABASE_PASSWORD=test
+# if you're using MySQL and Sequilize you should put
+# the password between single quotes otherwise you won't be able to 
+# connect to the database
+DATABASE_PASSWORD='your_super_secure_password_here'
 DATABASE_USERNAME=test
 DATABASE_SERVER=localhost
 DATABASE_NAME=test

--- a/app.js
+++ b/app.js
@@ -62,12 +62,13 @@ SallaAPI.onAuth(async (accessToken, refreshToken, expires_in, data) => {
       });
       await SallaDatabase.saveOauth(
         {
-          merchant: data.store.id,
+          merchant: data.id,
+          email: data.email,
           access_token: accessToken,
           expires_in: expires_in,
           refresh_token: refreshToken,
+          user_id
         },
-        user_id
       );
     })
     .catch((err) => {

--- a/database/index.js
+++ b/database/index.js
@@ -1,5 +1,4 @@
-///
-
+const getUnixTimestamp = require("../helpers/getUnixTimestamp");
 class SallaDatabase {
   constructor(DATABASE_ORM) {
     this.Database = require("../helpers/ORMs/" + DATABASE_ORM);
@@ -74,16 +73,12 @@ class SallaDatabase {
     if (this.DATABASE_ORM == "Sequelize") {
       if (
         // if not found then create new user
-        !(await this.connection.models.User.findOne({
+        (await this.connection.models.User.findOne({
           where: { email: data.email },
         }))
       ) {
         this.connection.models.OauthTokens.create({
-          user_id: user_id,
-          merchant: data.store.id,
-          access_token: data.accessToken,
-          expires_in: data.expires_in,
-          refresh_token: data.refreshToken,
+          ...data
         })
           .then((data) => {})
           .catch((err) => {


### PR DESCRIPTION
# Description
This PR contains 3 crucial fixes related to saving OAuth tokens in the database, namely MySQL and Sequelize ORM. This database and ORM combination is a popular choice for many developers. On the other side, there is a fix that is independent of the database or ORM options.

# Fixes

1️⃣ in `app.js`, `SallaAPI.onAuth` function , there is a bug in using `data.store.id` , you should use `data.id` instead
**Type of change**
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

2️⃣ in `database/index.js`, there is a missing import that crashing the database write
```
const getUnixTimestamp = require("../helpers/getUnixTimestamp");
```
**Type of change**
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)



3️⃣ adding a useful thing in `.env.example`
**Type of change**
- [x] non-breaking change, just a comment