### PR TITLE
feat(DVO-2820): Github Token Migration [skip ci]

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -19,13 +19,21 @@ jobs:
     name: Validate PR title
     runs-on: ${{ fromJSON(vars.RUNS_ON) }}
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GIT_APP_ID }}
+          private-key: ${{ secrets.GIT_APP_PRIVATE_KEY }}
+          owner: SallaApp
+
       # skip on new commits and on body-only edits
       - if: >-
           github.event.action != 'synchronize' &&
           (github.event.action != 'edited' || github.event.changes.title != null)
         uses: SallaApp/.CI/lint-pr@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
 
   branch:
     name: Validate branch name


### PR DESCRIPTION
Completes the move off `secrets.GITHUB_TOKEN` in this repo's workflows.

**What changed**
- `secrets.GITHUB_TOKEN` reference in `lint-pr.yaml` now uses a GitHub App installation token minted in-workflow via `actions/create-github-app-token@v1` (`GIT_APP_ID` / `GIT_APP_PRIVATE_KEY`).
- The `title` job gets the token-generation step as its first step; the `branch` job is untouched since it never used a token.

**Note on behaviour** — `GITHUB_TOKEN` deliberately does not trigger new workflow runs; App installation tokens do. This job only posts PR title lint feedback, so no downstream workflow-trigger changes are expected.

**Before merging** the App needs: Pull requests: write, Issues: write, Metadata: read.

Part of DVO-2820.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the workflow's default GitHub token with a GitHub App installation token.
- Adds in-workflow App-token generation using repository secrets.
- Passes the generated token to the PR-title lint action.
- Leaves the branch-name lint job unchanged.

<details open><summary><h3>Confidence Score: 0/5</h3></summary>

The PR is not safe to merge until token generation is aligned with the skipped title-lint path and both mutable action and excessive installation-scope credential risks are fixed.

Token generation still runs on events where title linting is skipped, the long-lived private key is passed to a mutable action tag, the installation token remains broader than this repository, and that write-capable token is forwarded to another action resolved from a mutable branch.

**Files Needing Attention:** .github/workflows/lint-pr.yaml
</details>

<details open><summary><h3>Security Review</h3></summary>

The generated write-capable installation token is passed to `SallaApp/.CI/lint-pr@master`, allowing a retargeted or compromised mutable branch to consume or exfiltrate it. **How this was verified:** The workflow resolves the custom action from `master` and supplies that action with `steps.app-token.outputs.token`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/lint-pr.yaml | Migrates title linting to a GitHub App token, but the token lifecycle, installation scope, and mutable action references leave workflow reliability and credential-boundary defects. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/lint-pr.yaml:37
**Mutable action receives App token**

If the `SallaApp/.CI` repository's `master` branch is retargeted or compromised, the workflow resolves the modified `lint-pr` action at runtime and supplies it with the write-capable App installation token, allowing the token to be exfiltrated or misused against covered pull requests or issues.

**How this was verified:** The workflow invokes `SallaApp/.CI/lint-pr@master` and passes `steps.app-token.outputs.token` directly to it.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["\[skip ci\]"](https://github.com/sallaapp/express-starter-kit/commit/9dc4fecaa3a504e7a537a34c1d305375a33b4c59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53908125)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->